### PR TITLE
Disambiguate ObserverBuilder

### DIFF
--- a/Sources/Operations/Operation/Observers/ObserverBuilder.swift
+++ b/Sources/Operations/Operation/Observers/ObserverBuilder.swift
@@ -10,24 +10,24 @@ import Foundation
 
 public final class ObserverBuilder {
     
-    private var startHandler: ((Operation) -> Void)?
-    private var produceHandler: ((Operation, NSOperation) -> Void)?
-    private var finishHandler: ((Operation) -> Void)?
+    private var startHandler: ((Void) -> Void)?
+    private var produceHandler: ((NSOperation) -> Void)?
+    private var finishHandler: ((Void) -> Void)?
     private var errorHandler: (([ErrorType]) -> Void)?
     
 }
 
 extension ObserverBuilder {
     
-    public func didStart(handler: (Operation -> Void)) {
+    public func didStart(handler: ((Void) -> Void)) {
         self.startHandler = handler
     }
     
-    public func didProduceAnotherOperation(handler: ((Operation, NSOperation) -> Void)) {
+    public func didProduceAnotherOperation(handler: ((NSOperation) -> Void)) {
         self.produceHandler = handler
     }
     
-    public func didFinish(handler: ((Operation) -> Void)) {
+    public func didFinish(handler: ((Void) -> Void)) {
         self.finishHandler = handler
     }
     
@@ -46,16 +46,16 @@ private struct ObserverBuilderObserver: OperationObserver {
     }
     
     private func operationDidStart(operation: Operation) {
-        builder.startHandler?(operation)
+        builder.startHandler?()
     }
     
     private func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
-        builder.produceHandler?(operation, newOperation)
+        builder.produceHandler?(newOperation)
     }
     
     private func operationDidFinish(operation: Operation, errors: [ErrorType]) {
         if errors.isEmpty {
-            builder.finishHandler?(operation)
+            builder.finishHandler?()
         } else {
             builder.errorHandler?(errors)
         }

--- a/Tests/OperationsTests.swift
+++ b/Tests/OperationsTests.swift
@@ -42,9 +42,9 @@ class OperationsTests: XCTestCase {
         }
         operation.observe {
             $0.didStart {
-                print($0)
+                print("Started")
             }
-            $0.didFinish { operation in
+            $0.didFinish {
                 expectation.fulfill()
             }
             $0.didFailed { errors in

--- a/Tests/OperationsTests.swift
+++ b/Tests/OperationsTests.swift
@@ -35,7 +35,7 @@ class OperationsTests: XCTestCase {
         }
     }
     
-    func testBuilder() {
+    func testRegularBuilder() {
         let expectation = expectationWithDescription("Operation waiting")
         let operation = BlockOperation {
             print("here")
@@ -44,11 +44,31 @@ class OperationsTests: XCTestCase {
             $0.didStart {
                 print("Started")
             }
-            $0.didFinish {
+            $0.didSuccess {
                 expectation.fulfill()
             }
-            $0.didFailed { errors in
+            $0.didFail { errors in
                 print(errors)
+            }
+        }
+        queue.addOperation(operation)
+        waitForExpectationsWithTimeout(10.0, handler: nil)
+    }
+    
+    func testBuilderWithFinished() {
+        let expectation = expectationWithDescription("Operation waiting")
+        let operation = BlockOperation {
+            print("here")
+        }
+        operation.observe {
+            $0.didFinishWithErrors { _ in
+                expectation.fulfill()
+            }
+            $0.didSuccess {
+                XCTFail()
+            }
+            $0.didFail { _ in
+                XCTFail()
             }
         }
         queue.addOperation(operation)


### PR DESCRIPTION
`didFailed` → `didFail`, `didFinish` → `didSuccess`.
And also introducing `didFinishWithErrors` which is useful in similar cases:

``` swift
// Example from OperationQueue implementation
operation.observe {
    $0.didFinishWithErrors { [weak self] errors in
        if let queue = self {
            queue.delegate?.operationQueue(queue, operationDidFinish: operation, withErrors: errors)
        }
    }
}
```

(When we don’t care much about whether the operation have finished successfully or with errors)
Also, if `didFinishWithErrors` is set, `didSuccess` and `didFail` will be ignored. 

This PR depends on #5 
