### PR TITLE
Enqueuing modules support

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		BE6B109F1CF0E75F00616E32 /* NoCancelledDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */; };
 		BE6B10A01CF0E75F00616E32 /* NoCancelledDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */; };
 		BE6B10A11CF0E75F00616E32 /* NoCancelledDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */; };
+		BE6CFCBF1D2AA9C50064041E /* QueueModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CFCBE1D2AA9C50064041E /* QueueModuleTests.swift */; };
+		BE6CFCC01D2AA9C50064041E /* QueueModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CFCBE1D2AA9C50064041E /* QueueModuleTests.swift */; };
+		BE6CFCC11D2AA9C50064041E /* QueueModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CFCBE1D2AA9C50064041E /* QueueModuleTests.swift */; };
 		BEFD74CF1CD630BA0066A71B /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */; };
 		BEFD74D01CD630BA0066A71B /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */; };
 		BEFD74D11CD630BA0066A71B /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */; };
@@ -123,6 +126,7 @@
 		BE47728D1CE71BEC00FF8DAC /* ObserverBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverBuilder.swift; sourceTree = "<group>"; };
 		BE6B10981CF0E66200616E32 /* MutuallyExclusive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutuallyExclusive.swift; sourceTree = "<group>"; };
 		BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoCancelledDependencies.swift; sourceTree = "<group>"; };
+		BE6CFCBE1D2AA9C50064041E /* QueueModuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueModuleTests.swift; sourceTree = "<group>"; };
 		BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExclusivityController.swift; sourceTree = "<group>"; };
 		BEFD74D31CD630CD0066A71B /* OperationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationQueue.swift; sourceTree = "<group>"; };
 		BEFD74D81CD633010066A71B /* BlockObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockObserver.swift; sourceTree = "<group>"; };
@@ -217,6 +221,7 @@
 			children = (
 				BE17C4491CD3CCD700708FC5 /* Info.plist */,
 				BE17C4471CD3CCD700708FC5 /* OperationsTests.swift */,
+				BE6CFCBE1D2AA9C50064041E /* QueueModuleTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -605,6 +610,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE17C4481CD3CCD700708FC5 /* OperationsTests.swift in Sources */,
+				BE6CFCBF1D2AA9C50064041E /* QueueModuleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -635,6 +641,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE17C49C1CD3CE3D00708FC5 /* OperationsTests.swift in Sources */,
+				BE6CFCC01D2AA9C50064041E /* QueueModuleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -687,6 +694,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE17C49D1CD3CE3E00708FC5 /* OperationsTests.swift in Sources */,
+				BE6CFCC11D2AA9C50064041E /* QueueModuleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Operations/OperationQueue/OperationQueue.swift
+++ b/Sources/Operations/OperationQueue/OperationQueue.swift
@@ -27,6 +27,9 @@ extension OperationQueueDelegate {
     public func operationQueue(operationQueue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [ErrorType]) { }
 }
 
+/// The block that is called when operation is enqueued.
+public typealias OperationQueueEnqueuingModule = (operation: Operation, queue: OperationQueue) -> Void
+
 /**
     `OperationQueue` is an `NSOperationQueue` subclass that implements a large
     number of "extra features" related to the `Operation` class:
@@ -84,6 +87,11 @@ public class OperationQueue: NSOperationQueue {
                 }
             }
             
+            // Connecting all user-defined modules. That's a fine alternative to delegates.
+            for module in modules {
+                module(operation: operation, queue: self)
+            }
+            
             /*
                 Indicate to the operation that we've finished our extra work on it
                 and it's now it a state where it can proceed with evaluating conditions,
@@ -123,4 +131,11 @@ public class OperationQueue: NSOperationQueue {
             }
         }
     }
+    
+    private var modules: [OperationQueueEnqueuingModule] = []
+    
+    public func addEnqueuingModule(module: OperationQueueEnqueuingModule) {
+        modules.append(module)
+    }
+    
 }

--- a/Tests/OperationsTests.swift
+++ b/Tests/OperationsTests.swift
@@ -23,18 +23,6 @@ class OperationsTests: XCTestCase {
         super.tearDown()
     }
     
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
     func testRegularBuilder() {
         let expectation = expectationWithDescription("Operation waiting")
         let operation = BlockOperation {

--- a/Tests/QueueModuleTests.swift
+++ b/Tests/QueueModuleTests.swift
@@ -1,0 +1,32 @@
+//
+//  QueueModuleTests.swift
+//  Operations
+//
+//  Created by Oleg Dreyman on 04.07.16.
+//  Copyright © 2016 AdvancedOperations. All rights reserved.
+//
+
+import XCTest
+@testable import Operations
+
+class QueueModuleTests: XCTestCase {
+    
+    func testBasicModule() {
+        let testQueue = OperationQueue()
+        let expectation = expectationWithDescription("Operation is running")
+        testQueue.addEnqueuingModule { operation, queue in
+            operation.observe {
+                $0.didSuccess {
+                    print("I'm ready")
+                    expectation.fulfill()
+                }
+            }
+        }
+        let testPrinter = BlockOperation {
+            print("I'm blocked :)")
+        }
+        testQueue.addOperation(testPrinter)
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+    }
+
+}


### PR DESCRIPTION
This allows to create even more complex and sophisticated behaviors using operation queues. For example:

``` swift
let queue = OperationQueue()
queue.addEnqueuingModule { operation, queue
    let logger = LogObserver(queueName: queue.name)
    operation.addObserver(logger)
}
```

And with the little help from the API design, we can achieve this:

``` swift
let queue = OperationQueue()
queue.addEnqueuingModule(LogObserver.enqueuingModule)
```

This basically attaches `LogObserver` to any enqueued operation (awesome!).
More, we can achieve some cool things with modules and POP (Protocol-Oriented Programming):

``` swift
protocol NetworkOperation { }

let queue = OperationQueue()
queue.addEnqueuingModule { operation, queue in
    if operation is NetworkOperation {
        let indicatorSwitcher = NetworkObserver()
        operation.addObserver(indicatorSwitcher)
    }
}
```
