### PR TITLE
Concept of vital operations

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		BE6B109F1CF0E75F00616E32 /* NoCancelledDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */; };
 		BE6B10A01CF0E75F00616E32 /* NoCancelledDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */; };
 		BE6B10A11CF0E75F00616E32 /* NoCancelledDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */; };
+		BE6CFCC31D2AAB380064041E /* VitalOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CFCC21D2AAB380064041E /* VitalOperationsTests.swift */; };
+		BE6CFCC41D2AAB380064041E /* VitalOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CFCC21D2AAB380064041E /* VitalOperationsTests.swift */; };
+		BE6CFCC51D2AAB380064041E /* VitalOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CFCC21D2AAB380064041E /* VitalOperationsTests.swift */; };
 		BEFD74CF1CD630BA0066A71B /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */; };
 		BEFD74D01CD630BA0066A71B /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */; };
 		BEFD74D11CD630BA0066A71B /* ExclusivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */; };
@@ -123,6 +126,7 @@
 		BE47728D1CE71BEC00FF8DAC /* ObserverBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverBuilder.swift; sourceTree = "<group>"; };
 		BE6B10981CF0E66200616E32 /* MutuallyExclusive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutuallyExclusive.swift; sourceTree = "<group>"; };
 		BE6B109D1CF0E75F00616E32 /* NoCancelledDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoCancelledDependencies.swift; sourceTree = "<group>"; };
+		BE6CFCC21D2AAB380064041E /* VitalOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalOperationsTests.swift; sourceTree = "<group>"; };
 		BEFD74CE1CD630BA0066A71B /* ExclusivityController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExclusivityController.swift; sourceTree = "<group>"; };
 		BEFD74D31CD630CD0066A71B /* OperationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationQueue.swift; sourceTree = "<group>"; };
 		BEFD74D81CD633010066A71B /* BlockObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockObserver.swift; sourceTree = "<group>"; };
@@ -217,6 +221,7 @@
 			children = (
 				BE17C4491CD3CCD700708FC5 /* Info.plist */,
 				BE17C4471CD3CCD700708FC5 /* OperationsTests.swift */,
+				BE6CFCC21D2AAB380064041E /* VitalOperationsTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -604,6 +609,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE6CFCC31D2AAB380064041E /* VitalOperationsTests.swift in Sources */,
 				BE17C4481CD3CCD700708FC5 /* OperationsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,6 +640,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE6CFCC41D2AAB380064041E /* VitalOperationsTests.swift in Sources */,
 				BE17C49C1CD3CE3D00708FC5 /* OperationsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -686,6 +693,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE6CFCC51D2AAB380064041E /* VitalOperationsTests.swift in Sources */,
 				BE17C49D1CD3CE3E00708FC5 /* OperationsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -156,6 +156,12 @@ public class Operation: NSOperation {
         }
     }
     
+    public var vital: Bool = false {
+        willSet {
+            assert(state < .Pending, "Cannot modify vital after operation has enqueued")
+        }
+    }
+    
     public var userInitiated: Bool {
         get {
             return qualityOfService == .UserInitiated

--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -155,13 +155,7 @@ public class Operation: NSOperation {
             return false
         }
     }
-    
-    public var vital: Bool = false {
-        willSet {
-            assert(state < .Pending, "Cannot modify vital after operation has enqueued")
-        }
-    }
-    
+        
     public var userInitiated: Bool {
         get {
             return qualityOfService == .UserInitiated

--- a/Sources/Operations/OperationQueue/OperationQueue.swift
+++ b/Sources/Operations/OperationQueue/OperationQueue.swift
@@ -126,8 +126,8 @@ public class OperationQueue: NSOperationQueue {
     }
     
     public func addOperation(operation: NSOperation, vital: Bool) {
-        addOperation(operation)
         addDependency(operation)
+        addOperation(operation)
     }
     
     private let vitalAccessQueue = dispatch_queue_create("com.AdvancedOperations.VitalOperationsAccessQueue", DISPATCH_QUEUE_SERIAL)

--- a/Tests/VitalOperationsTests.swift
+++ b/Tests/VitalOperationsTests.swift
@@ -1,0 +1,64 @@
+//
+//  VitalOperationsTests.swift
+//  Operations
+//
+//  Created by Oleg Dreyman on 04.07.16.
+//  Copyright © 2016 AdvancedOperations. All rights reserved.
+//
+
+import XCTest
+@testable import Operations
+
+class VitalOperationsTests: XCTestCase {
+
+    func testVitalOperation() {
+        let testQueue = OperationQueue()
+        let importantPrinter = BlockOperation {
+            print("I am so freaking important so I'll make anyone wait for me, bitches")
+        }
+        importantPrinter.vital = true
+        testQueue.addOperation(importantPrinter)
+        let expectation = expectationWithDescription("Waiting for next operation to start")
+        let lessImportantPrinter = BlockOperation {
+            print("I am just a regular printer")
+        }
+        lessImportantPrinter.observe { operation in
+            operation.didStart {
+                if !importantPrinter.finished {
+                    XCTFail("This operation should wait for vitals")
+                }
+            }
+            operation.didSuccess {
+                expectation.fulfill()
+            }
+        }
+        testQueue.addOperation(lessImportantPrinter)
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+    }
+    
+    func testMultipleVitals() {
+        let testQueue = OperationQueue()
+        var last = -1
+        for index in 0 ... 5 {
+            let important = BlockOperation {
+                XCTAssertEqual(last, index - 1)
+                print("I am so \(index) important")
+                last = index
+            }
+            important.vital = true
+            testQueue.addOperation(important)
+        }
+        let expectation = expectationWithDescription("Waiting for start of non-vital operation")
+        let nonImportant = BlockOperation {
+            print("Regular is my style")
+        }
+        nonImportant.observe {
+            $0.didSuccess {
+                expectation.fulfill()
+            }
+        }
+        testQueue.addOperation(nonImportant)
+        waitForExpectationsWithTimeout(8.0, handler: nil)
+    }
+
+}


### PR DESCRIPTION
This PR introduces the concept of «vital» operations, i.e. operations which completion is critical to executing any following operations in the queue. This means that queue will be blocked until vital operation is finished. Marking operation is vital is very simple:

``` swift
let operation = SuperImportantOperation()
queue.addOperation(operation, vital: true)
```

or:

``` swift
let operation = SuperImportantOperation()
queue.addDependency(operation)
queue.addOperation(operation)
```

Second option might be useful with «multi-queue vitality».

Behind the scenes `OperationQueue` actually tracks the execution of such vital operation and makes any enqueued operation depending on it until it’s finished.

You should also not try to set `vital` property after you’ve enqueued an operation. There is an `assert` for that, so be careful.
