### PR TITLE
GroupOperation queue configuration and convenience

### DIFF
--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -156,6 +156,12 @@ public class Operation: NSOperation {
         }
     }
     
+    public var vital: Bool = false {
+        willSet {
+            assert(state < .Pending, "Cannot modify vital after operation has enqueued")
+        }
+    }
+    
     public var userInitiated: Bool {
         get {
             return qualityOfService == .UserInitiated

--- a/Sources/Operations/Operation/Operations/GroupOperation.swift
+++ b/Sources/Operations/Operation/Operations/GroupOperation.swift
@@ -28,13 +28,10 @@ public class GroupOperation: Operation {
 
     private var aggregatedErrors = [ErrorType]()
     
-    public convenience init(operations: NSOperation...) {
-        self.init(operations: operations)
-    }
-    
-    public init(operations: [NSOperation]) {
+    public init(operations: [NSOperation], configureQueue: ((OperationQueue) -> Void)? = nil) {
         super.init()
         
+        configureQueue?(internalQueue)
         internalQueue.suspended = true
         internalQueue.delegate = self
         internalQueue.addOperation(startingOperation)
@@ -70,6 +67,12 @@ public class GroupOperation: Operation {
     public func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
         // For use by subclassers.
     }
+    
+    // This method is called right before GroupOperation finishes it's execution. Do not try to add any more operations at this point.
+    public func groupOperationWillFinish() {
+        // For use by subclassers
+    }
+    
 }
 
 extension GroupOperation: OperationQueueDelegate {
@@ -102,6 +105,7 @@ extension GroupOperation: OperationQueueDelegate {
         
         if operation === finishingOperation {
             internalQueue.suspended = true
+            groupOperationWillFinish()
             finish(aggregatedErrors)
         }
         else if operation !== startingOperation {


### PR DESCRIPTION
This PR adds two new features:
1) `groupOperationWillFinish()` customization point is called right before GroupOperation finishes it's execution. Nice point for any clean up.
2) `init(operations:configureQueue:)`. This point allows subclasses to customize internal queue which is private to the `GroupOperation`. Here one can add custom enqueueing modules, specialize queue name, priority, `maxConcurrentOperationCount` and so on. This is the only place where you can change the behavior of `GroupOperation` internal queue.
Real-life example:

``` swift
class SetImagesOperation: GroupOperation {
    init(managedObjectContext context: NSManagedObjectContext) {
        let child = NSManagedObjectContext(parent: context)
        self.context = child
        super.init(operations: [], configureQueue: {
            // convenience method for `LogObserver` enqueuing module
            $0.connectLogger()
            $0.name = "Image Download Queue"
            $0.qualityOfService = .Utility
            $0.maxConcurrentOperationCount = 10
        })
    }
/* ------- */
}
```

Depends on #15 for some reason ¯_(ツ)_/¯
