### PR TITLE
Rename cancelWithError(_:) to cancel(with:)

### DIFF
--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -268,10 +268,8 @@ public class Operation: NSOperation {
     }
     
     private var _internalErrors = [ErrorType]()
-    public func cancelWithError(error: ErrorType? = nil) {
-        if let error = error {
-            _internalErrors.append(error)
-        }
+    public func cancel(with error: ErrorType) {
+        _internalErrors.append(error)
         cancel()
     }
     


### PR DESCRIPTION
Renaming for the sake of consistency with the rest of the library.
As so, we now have `finish(with:)`. `finish(withError:)` and `cancel(with:)`. Also `.Failed(with:)` on `OperationConditionResult`.
Also, `error` inside is no longer optional. 
