### PR TITLE
Add configure() customization point

### DIFF
--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -85,6 +85,16 @@ public class Operation: NSOperation {
         }
     }
     
+    public override init() {
+        super.init()
+        configure()
+    }
+    
+    /// The good place to setup observers, conditions and mutual exclusivity categories.
+    public func configure() {
+        // For use by subclassers.
+    }
+    
     internal func _willEnqueue() {
         state = .Pending
         willEnqueue()

--- a/Tests/OperationsTests.swift
+++ b/Tests/OperationsTests.swift
@@ -63,4 +63,20 @@ class OperationsTests: XCTestCase {
         waitForExpectationsWithTimeout(10.0, handler: nil)
     }
     
+    func testConfigure() {
+        let expectation = expectationWithDescription("Test")
+        class TestOperation: Operation {
+            let expectation: XCTestExpectation
+            init(expectation: XCTestExpectation) {
+                self.expectation = expectation
+            }
+            override func configure() {
+                print("Configured")
+                expectation.fulfill()
+            }
+        }
+        _ = TestOperation(expectation: expectation)
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+    }
+    
 }


### PR DESCRIPTION
The good place to setup observers, conditions and mutual exclusivity categories, instead of after `super.init()`.

Remember that your `configure()` can be overridden, so mark it as `final` in your subclass if you don’t want any other behavior than described.
