### PR TITLE
Substitute Bool flags with OptionSets

### DIFF
--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -229,12 +229,21 @@ public class Operation: NSOperation {
         super.addDependency(operation)
     }
     
+    public struct DependencyOptions: OptionSetType {
+        public var rawValue: Int
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+        
+        public static let ExpectSuccess = DependencyOptions(rawValue: 1 << 0)
+    }
+    
     /// Makes the receiver dependent on the completion of the specified operation.
     ///
     /// - Parameter expectSuccess: If `true`, `self` operation will fail if `operation` fails.
-    public func addDependency(operation: Operation, expectSuccess: Bool) {
+    public func addDependency(operation: Operation, options: [DependencyOptions]) {
         addDependency(operation)
-        if expectSuccess {
+        if options.contains(.ExpectSuccess) {
             addCondition(NoFailedDependency(dependency: operation))
         }
     }

--- a/Sources/Operations/OperationQueue/OperationQueue.swift
+++ b/Sources/Operations/OperationQueue/OperationQueue.swift
@@ -139,11 +139,22 @@ public class OperationQueue: NSOperationQueue {
         modules.append(module)
     }
     
+    public struct EnqueuingOptions: OptionSetType {
+        public var rawValue: Int
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+        
+        public static let Vital = EnqueuingOptions(rawValue: 1 << 0)
+    }
+    
     /// Adds an operation to the queue. The operation will "block" the queue if `vital` is true.
     ///
     /// - Parameter vital: If `true`, `operation` will be marked as vital (no other operation on the queue can start until this one is finished).
-    public func addOperation(operation: NSOperation, vital: Bool) {
-        addDependency(operation)
+    public func addOperation(operation: NSOperation, options: [EnqueuingOptions]) {
+        if options.contains(.Vital) {
+            addDependency(operation)
+        }
         addOperation(operation)
     }
     

--- a/Tests/NoFailedTests.swift
+++ b/Tests/NoFailedTests.swift
@@ -66,8 +66,8 @@ class NoFailedTests: XCTestCase {
             })
         }
         
-        noFailMain.addDependency(fail1, expectSuccess: true)
-        noFailMain.addDependency(noFail1, expectSuccess: true)
+        noFailMain.addDependency(fail1, options: [.ExpectSuccess])
+        noFailMain.addDependency(noFail1, options: [.ExpectSuccess])
         queue.addOperation(fail1)
         queue.addOperation(noFail1)
         queue.addOperation(noFailMain)

--- a/Tests/VitalOperationsTests.swift
+++ b/Tests/VitalOperationsTests.swift
@@ -16,7 +16,7 @@ class VitalOperationsTests: XCTestCase {
         let importantPrinter = BlockOperation {
             print("I am so freaking important so I'll make anyone wait for me, bitches")
         }
-        testQueue.addOperation(importantPrinter, vital: true)
+        testQueue.addOperation(importantPrinter, options: [.Vital])
         let expectation = expectationWithDescription("Waiting for next operation to start")
         let lessImportantPrinter = BlockOperation {
             print("I am just a regular printer")
@@ -65,7 +65,7 @@ class VitalOperationsTests: XCTestCase {
         let importantPrinter = BlockOperation {
             print("I am so freaking important so I'll make anyone wait for me, bitches")
         }
-        testQueue.addOperation(importantPrinter, vital: true)
+        testQueue.addOperation(importantPrinter, options: [.Vital])
         let expectation = expectationWithDescription("Waiting for next operation to start")
         let lessImportantPrinter = BlockOperation {
             print("I am just a regular printer")


### PR DESCRIPTION
Before:

``` swift
operation.addDependency(otherOperation, expectSuccess: true)
queue.addOperation(operation, vital: true)
```

After:

``` swift
operation.addDependency(otherOperation, options: [.ExpectSuccess])
queue.addOperation(operation, options: [.Vital])
```
