### PR TITLE
Error Resolving by blocks or reusable instances

### DIFF
--- a/Sources/Operations/Operation/Fallible.swift
+++ b/Sources/Operations/Operation/Fallible.swift
@@ -54,3 +54,21 @@ public protocol OperationErrorResolver {
     func resolve(error: DependencyError<Error>) -> ErrorResolvingDisposition
 }
 
+public protocol OperationNativeErrorResolver: OperationErrorResolver {
+    associatedtype Error: ErrorType
+    
+    func resolve(error: Error) -> ErrorResolvingDisposition
+}
+
+extension OperationNativeErrorResolver {
+    
+    func resolve(error: DependencyError<Error>) -> ErrorResolvingDisposition {
+        switch error {
+        case .Native(let error):
+            return resolve(error)
+        case .Foreign:
+            return .FailWithSame
+        }
+    }
+    
+}

--- a/Sources/Operations/Operation/Fallible.swift
+++ b/Sources/Operations/Operation/Fallible.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 AdvancedOperations. All rights reserved.
 //
 
+import Foundation
+
 public protocol Fallible {
     associatedtype Error: ErrorType
 }
@@ -46,6 +48,7 @@ public enum ErrorResolvingDisposition {
     case Execute
     case FailWithSame
     case Fail(with: ErrorType)
+    case Produce(NSOperation)
 }
 
 public protocol OperationErrorResolver {

--- a/Sources/Operations/Operation/Fallible.swift
+++ b/Sources/Operations/Operation/Fallible.swift
@@ -27,3 +27,30 @@ extension Fallible where Self: Operation {
     }
     
 }
+
+public enum DependencyError<Error: ErrorType> {
+    case Native(Error)
+    case Foreign(ErrorType)
+    
+    public var native: Error? {
+        switch self {
+        case let .Native(error):
+            return error
+        default:
+            return nil
+        }
+    }
+}
+
+public enum ErrorResolvingDisposition {
+    case Execute
+    case FailWithSame
+    case Fail(with: ErrorType)
+}
+
+public protocol OperationErrorResolver {
+    associatedtype Error: ErrorType
+    
+    func resolve(error: DependencyError<Error>) -> ErrorResolvingDisposition
+}
+

--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -420,6 +420,8 @@ internal struct ErrorResolverObserver<Error: ErrorType>: OperationObserver {
                 disposedErrors.append(error)
             case let .Fail(with: customError):
                 disposedErrors.append(customError)
+            case let .Produce(newOperation):
+                operation.produceOperation(newOperation)
             }
         }
         if !disposedErrors.isEmpty {

--- a/Sources/Operations/Operation/Operation.swift
+++ b/Sources/Operations/Operation/Operation.swift
@@ -238,12 +238,12 @@ public class Operation: NSOperation {
         public static let ExpectSuccess = DependencyOptions(rawValue: 1 << 0)
     }
     
-    public func addDependency<FallibleOperation: Operation where FallibleOperation: Fallible>(operation: FallibleOperation, resolveError: (DependencyError<FallibleOperation.Error>) -> ErrorResolvingDisposition) {
+    public final func addDependency<FallibleOperation: Operation where FallibleOperation: Fallible>(operation: FallibleOperation, resolveError: (DependencyError<FallibleOperation.Error>) -> ErrorResolvingDisposition) {
         operation.addObserver(ErrorResolverObserver(resolve: resolveError, dependee: self))
         addDependency(operation)
     }
     
-    public func addDependency<FallibleOperation, Resolver
+    public final func addDependency<FallibleOperation, Resolver
         where FallibleOperation: Operation,
         FallibleOperation: Fallible,
         Resolver: OperationErrorResolver,


### PR DESCRIPTION
Works only for `Fallible`. `.Native` is errors of `Fallible`, `.Foreign` is any other error.

``` swift
block.addDependency(justFail, resolveError: { error in
    switch error {
    case .Native(let error):
        switch error {
        case .B:
            return .Execute
        case .A:
            return .FailWithSame
        case .C:
            return .Fail(with: Test.Error)
        }
    case .Foreign:
        return .FailWithSame
    }
})
```
