### PR TITLE
ErrorInformer introduction

### DIFF
--- a/Sources/Operations/Operation/Conditions/NoFailedDependencies.swift
+++ b/Sources/Operations/Operation/Conditions/NoFailedDependencies.swift
@@ -63,9 +63,13 @@ internal struct NoFailedDependency: OperationCondition {
     }
     
     func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
-        guard let errors = dependency.errors else {
+        guard var errors = dependency.errors else {
             completion(.Failed(with: Error.DependencyErrorsNil))
             return
+        }
+        if let decider = dependency as? ErrorInformer {
+            errors = errors.filter({ decider.purpose(of: $0) == .Fatal })
+            print(errors)
         }
         if !errors.isEmpty {
             completion(.Failed(with: Error.DependencyFailed((operation, errors))))

--- a/Sources/Operations/Operation/Fallible.swift
+++ b/Sources/Operations/Operation/Fallible.swift
@@ -27,3 +27,14 @@ extension Fallible where Self: Operation {
     }
     
 }
+
+public enum ErrorPurpose {
+    case Fatal
+    case Informative
+}
+
+public protocol ErrorInformer {
+    
+    func purpose(of error: ErrorType) -> ErrorPurpose
+    
+}


### PR DESCRIPTION
If you sometime finish your operation reporting errors that are _not fatal_, but _informative_ (e.g. these errors shouldn’t stop the execution of upcoming operations), you can now conform to `ErrorInformer` protocol to decide which errors are not fatal. This gives you the benefits of using `.ExpectSuccess` option and `NoFailedDependencies` without cancelling the operations after non-fatal errors.
